### PR TITLE
Added image for PHP7 Teal elephpant

### DIFF
--- a/source/_elephpants/2015-10-19-teal-zend.md
+++ b/source/_elephpants/2015-10-19-teal-zend.md
@@ -3,7 +3,11 @@ categories:
     - teal
 sponsor: Zend Technologies
 reverse: Zend logo
+photos:
+    -	img: http://i.imgur.com/xJNpiQN.jpg
+        link: http://imgur.com/xJNpiQN
+        caption: Teal elephpant and composer require PHP:^7.0 by Mark Baker
 ---
 Also described as turquoise. This elephpant was given away to attendees at ZendCon 2015.
 
-The PHP logo on the obverse has a "7" included to signify the upcoming release of PHP 7.
+The PHP logo on the obverse has a "7" included to signify the release of PHP 7.

--- a/source/_elephpants/2015-11-06-black-symfony.md
+++ b/source/_elephpants/2015-11-06-black-symfony.md
@@ -3,6 +3,12 @@ categories:
     - black
 sponsor: Sensio Labs
 reverse: Symfony Framework 10 Years logo        
+photos:
+    -
+        img: http://i.imgur.com/jnVQgQV.jpg
+        link: http://imgur.com/jnVQgQV
+        caption: Black Symfony 10th anniversary elephpant by Mark Baker
+
 ---
 
 This elephpant was designed to celebrate the 10th anniversary of the [Symfony Framework](http://symfony.com/). Only 300 were available and were sold exclusively at [SymfonyCon 2015](http://pariscon2015.symfony.com/) in Paris.


### PR DESCRIPTION
Added appropriate image for the PHP7 Teal elephpant, seated on a composer require php:^7.0 t-shirt 