### PR TITLE
elephpant was also given out at php|tek.

### DIFF
--- a/source/_elephpants/2008-03-12-blue-oracle.md
+++ b/source/_elephpants/2008-03-12-blue-oracle.md
@@ -11,4 +11,5 @@ photos:
         link: https://www.flickr.com/photos/afilina/2339246540/
         credit: Anna Filina
 ---
-Given to attendees at the 2008 PHP Quebec Conference (now [ConFoo](http://confoo.ca)).
+Given to attendees at the 2008 PHP Quebec Conference (now [ConFoo](http://confoo.ca)), 
+and also to the attendees of the 2008 php|tek Conference (now [php[tek]](https://tek.phparch.com/)).


### PR DESCRIPTION
Evidence: https://www.flickr.com/photos/preinheimer/2508587135/in/photostream/