### PR TITLE
Convert "tags" taxonomy to "colors"

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -2,11 +2,11 @@ sculpin_content_types:
     elephpants:
         taxonomies:
             - categories
-            - tags
+            - colors
     others:
         taxonomies:
             - categories
-            - tags
+            - colors
     posts:
         enabled: false
     sections:

--- a/source/_elephpants/2007-12-00-blue-original.md
+++ b/source/_elephpants/2007-12-00-blue-original.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - original
-tags:
+colors:
     - blue
 sponsor: Nexen / Alter Way
 photos:

--- a/source/_elephpants/2008-03-12-blue-oracle.md
+++ b/source/_elephpants/2008-03-12-blue-oracle.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - oracle
-tags:
+colors:
     - blue
 sponsor: Oracle Corporation
 reverse: Oracle logo

--- a/source/_elephpants/2010-11-01-blue-zend.md
+++ b/source/_elephpants/2010-11-01-blue-zend.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - zend
-tags:
+colors:
     - blue
 sponsor: Zend Technologies
 reverse: Zend logo

--- a/source/_elephpants/2011-10-00-pink-original.md
+++ b/source/_elephpants/2011-10-00-pink-original.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - original
-tags:
+colors:
     - pink
 sponsor: Alter Way
 photos:

--- a/source/_elephpants/2012-09-00-green-zf2.md
+++ b/source/_elephpants/2012-09-00-green-zf2.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - zf2
-tags:
+colors:
     - green
 sponsor: Zend Technologies, Inc.
 reverse: Zend Framework 2 logo

--- a/source/_elephpants/2013-10-07-red-chili.md
+++ b/source/_elephpants/2013-10-07-red-chili.md
@@ -2,7 +2,7 @@
 name: Chili
 categories:
     - zend
-tags:
+colors:
     - red
 sponsor: Zend Technologies
 reverse: Zend logo

--- a/source/_elephpants/2014-01-16-orange-phparch.md
+++ b/source/_elephpants/2014-01-16-orange-phparch.md
@@ -2,7 +2,7 @@
 name: Archie
 categories:
     - phparch
-tags:
+colors:
     - orange
 sponsor: php[architect]
 reverse: php[architect] logo

--- a/source/_elephpants/2014-02-06-purple-phpwomen.md
+++ b/source/_elephpants/2014-02-06-purple-phpwomen.md
@@ -2,7 +2,7 @@
 name: Umoja
 categories:
     - phpwomen
-tags:
+colors:
     - purple
 sponsor: PHP Women
 reverse: PHP Women logo

--- a/source/_elephpants/2014-02-06-yellow-sunshinephp.md
+++ b/source/_elephpants/2014-02-06-yellow-sunshinephp.md
@@ -2,7 +2,7 @@
 name: Sonny
 categories:
     - sunshinephp
-tags:
+colors:
     - yellow
 sponsor: Sunshine PHP Conference, Zend Technologies
 reverse: Sunshine PHP logo, Zend logo

--- a/source/_elephpants/2014-09-05-red-laravel.md
+++ b/source/_elephpants/2014-09-05-red-laravel.md
@@ -2,7 +2,7 @@
 name: Liona
 categories:
     - laravel
-tags:
+colors:
     - red
 sponsor: Laravel community
 reverse: Laravel logo

--- a/source/_elephpants/2014-10-28-blue-apigility.md
+++ b/source/_elephpants/2014-10-28-blue-apigility.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - zend
-tags:
+colors:
     - blue
 sponsor: Zend Technologies
 reverse: Zend logo

--- a/source/_elephpants/2014-10-28-blue-zray.md
+++ b/source/_elephpants/2014-10-28-blue-zray.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - zend
-tags:
+colors:
     - blue
 sponsor: Zend Technologies
 reverse: Zend logo

--- a/source/_elephpants/2014-11-27-black-amsterdamphp.md
+++ b/source/_elephpants/2014-11-27-black-amsterdamphp.md
@@ -2,7 +2,7 @@
 name: MurPHPy
 categories:
     - amsterdamphp
-tags:
+colors:
     - black
 sponsor: AmsterdamPHP
 reverse: AmsterdamPHP logo

--- a/source/_elephpants/2015-03-05-white-confoo.md
+++ b/source/_elephpants/2015-03-05-white-confoo.md
@@ -2,7 +2,7 @@
 name: Phil Snow
 categories:
     - confoo
-tags:
+colors:
     - white
 sponsor: ConFoo
 reverse: ConFoo.ca web techno conference

--- a/source/_elephpants/2015-06-08-gold-opengoodies.md
+++ b/source/_elephpants/2015-06-08-gold-opengoodies.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - gold
-tags:
+colors:
     - gold
 sponsor: OpenGoodies
 reverse: 20 Years 1995-2015

--- a/source/_elephpants/2015-06-19-blue-opengoodies.md
+++ b/source/_elephpants/2015-06-19-blue-opengoodies.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - original
-tags:
+colors:
     - blue
 sponsor: OpenGoodies
 photos:

--- a/source/_elephpants/2015-06-19-pink-opengoodies.md
+++ b/source/_elephpants/2015-06-19-pink-opengoodies.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - original
-tags:
+colors:
     - pink
 sponsor: OpenGoodies
 photos:

--- a/source/_elephpants/2015-10-13-multicolored-haphpy.md
+++ b/source/_elephpants/2015-10-13-multicolored-haphpy.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - haphpy
-tags:
+colors:
     - multicolored
 sponsor: Association Française des Utilisateurs de PHP (AFUP) - French PHP User Group
 photos:

--- a/source/_elephpants/2015-10-19-teal-zend.md
+++ b/source/_elephpants/2015-10-19-teal-zend.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - zend
-tags:
+colors:
     - teal
 sponsor: Zend Technologies
 reverse: Zend logo

--- a/source/_elephpants/2015-11-06-black-symfony-10-years.md
+++ b/source/_elephpants/2015-11-06-black-symfony-10-years.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - symfony
-tags:
+colors:
     - black
 sponsor: Sensio Labs
 reverse: Symfony Framework 10 Years logo        

--- a/source/_elephpants/2016-01-01-black-symfony.md
+++ b/source/_elephpants/2016-01-01-black-symfony.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - symfony
-tags:
+colors:
     - black
 sponsor: Sensio Labs
 reverse: Symfony Framework logo

--- a/source/_elephpants/2016-02-19-blue-shopware.md
+++ b/source/_elephpants/2016-02-19-blue-shopware.md
@@ -2,7 +2,7 @@
 name: Cody Blou
 categories:
     - shopware
-tags:
+colors:
     - blue
 sponsor: shopware AG
 reverse: shopware Logo

--- a/source/_elephpants/2016-06-02-white-globalis.md
+++ b/source/_elephpants/2016-06-02-white-globalis.md
@@ -2,7 +2,7 @@
 name: Echo
 categories:
     - globalis
-tags:
+colors:
     - white
 sponsor: GLOBALIS
 reverse: GLOBALIS logo

--- a/source/_elephpants/2016-06-24-white-dpc.md
+++ b/source/_elephpants/2016-06-24-white-dpc.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - dpc
-tags:
+colors:
     - white
 sponsor: ibuildings
 reverse: ibuildings Dutch PHP Conference, with the DPC logo

--- a/source/_elephpants/2016-10-18-white-zend.md
+++ b/source/_elephpants/2016-10-18-white-zend.md
@@ -2,7 +2,7 @@
 name: ElPHPis
 categories:
     - zend
-tags:
+colors:
     - white
 sponsor: Zend Technologies
 reverse: Zend logo

--- a/source/_elephpants/2016-10-27-multicolored-phpdiversity.md
+++ b/source/_elephpants/2016-10-27-multicolored-phpdiversity.md
@@ -2,7 +2,7 @@
 name: Enfys
 categories:
     - rainbow
-tags:
+colors:
     - multicolored
 sponsor: PHPDiversity
 photos:

--- a/source/_elephpants/2017-02-02-gray-roave.md
+++ b/source/_elephpants/2017-02-02-gray-roave.md
@@ -2,7 +2,7 @@
 name: Chloe
 categories:
     - roave
-tags:
+colors:
     - gray
 sponsor: Roave
 reverse: Roave logo

--- a/source/_elephpants/2017-05-19-blue-afup.md
+++ b/source/_elephpants/2017-05-19-blue-afup.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - afup
-tags:
+colors:
     - blue
 sponsor: Association Française des Utilisateurs de PHP (AFUP) - French PHP User Group
 reverse: AFUP logo

--- a/source/_elephpants/2017-06-11-blue-cakedc.md
+++ b/source/_elephpants/2017-06-11-blue-cakedc.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - cakephp
-tags:
+colors:
     - blue
 sponsor: Cake Development Corporation
 reverse: CakeDC logo

--- a/source/_elephpants/2017-06-11-blue-cakefest.md
+++ b/source/_elephpants/2017-06-11-blue-cakefest.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - cakephp
-tags:
+colors:
     - blue
 sponsor: CakePHP
 reverse: CakeFest logo

--- a/source/_elephpants/2017-06-11-red-cakephp.md
+++ b/source/_elephpants/2017-06-11-red-cakephp.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - cakephp
-tags:
+colors:
     - red
 sponsor: CakePHP
 reverse: CakePHP logo

--- a/source/_elephpants/2017-06-11-yellow-cakesf.md
+++ b/source/_elephpants/2017-06-11-yellow-cakesf.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - cakephp
-tags:
+colors:
     - yellow
 sponsor: CakePHP
 reverse: Cake Software Foundation logo

--- a/source/_elephpants/2017-09-22-denim-zend.md
+++ b/source/_elephpants/2017-09-22-denim-zend.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - zend
-tags:
+colors:
     - blue
 sponsor: Rogue Wave Software
 reverse: Rogue Wave/Zend logo

--- a/source/_elephpants/2017-10-06-purple-heroku.md
+++ b/source/_elephpants/2017-10-06-purple-heroku.md
@@ -2,7 +2,7 @@
 name: Hero
 categories:
     - heroku
-tags:
+colors:
     - purple
 sponsor: Heroku
 reverse: Heroku logo with starburst

--- a/source/_elephpants/2017-10-12-gray-magento.md
+++ b/source/_elephpants/2017-10-12-gray-magento.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - magento
-tags:
+colors:
     - gray
 sponsor: Magento
 reverse: Magento logo

--- a/source/_elephpants/2018-04-14-php-yorkshire.md
+++ b/source/_elephpants/2018-04-14-php-yorkshire.md
@@ -2,7 +2,7 @@
 name: Jorvik
 categories:
     - phpyorkshire
-tags:
+colors:
     - blue
 sponsor: PHP Yorkshire conference
 reverse: PHP Yorkshire logo

--- a/source/_elephpants/2018-05-30-purple-php-roundtable.md
+++ b/source/_elephpants/2018-05-30-purple-php-roundtable.md
@@ -2,7 +2,7 @@
 name: Pollita (in honor of Sara Golemon)
 categories:
     - phproundtable
-tags:
+colors:
     - purple
 sponsor: PHP Roundtable Podcast
 reverse: PHP Roundtable logo

--- a/source/_elephpants/2018-07-01-silver-phpvegas.md
+++ b/source/_elephpants/2018-07-01-silver-phpvegas.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - phpvegas
-tags:
+colors:
     - silver
 sponsor: PHPVegas
 reverse: PHP Vegas Text Logo

--- a/source/_elephpants/2018-10-15-blue-zendcon.md
+++ b/source/_elephpants/2018-10-15-blue-zendcon.md
@@ -2,7 +2,7 @@
 name: Zoe
 categories:
     - zend
-tags:
+colors:
     - blue
 sponsor: Rogue Wave Software
 reverse: Rogue Wave and Zend logos

--- a/source/_elephpants/2019-01-25-white-phpbenelux.md
+++ b/source/_elephpants/2019-01-25-white-phpbenelux.md
@@ -2,7 +2,7 @@
 name: Luxy
 categories:
     - phpbenelux
-tags:
+colors:
     - white
 sponsor: PHPBenelux Conference
 reverse: PHPBenelux Conference logo/"10 years of conferences"

--- a/source/_elephpants/2019-02-07-yellow-sunshinephp-nexmo.md
+++ b/source/_elephpants/2019-02-07-yellow-sunshinephp-nexmo.md
@@ -2,7 +2,7 @@
 name: Sonny
 categories:
     - sunshinephp
-tags:
+colors:
     - yellow
 sponsor: Sunshine PHP Conference, Nexmo
 reverse: Sunshine PHP logo, Nexmo logo

--- a/source/_elephpants/2019-06-07-yellow-darkmira.md
+++ b/source/_elephpants/2019-06-07-yellow-darkmira.md
@@ -2,7 +2,7 @@
 name: Unity
 categories:
     - darkmira
-tags:
+colors:
     - yellow
 sponsor: Darkmira Tour PHP
 reverse: Darkmira Tour PHP logo

--- a/source/_others/2015-06-02-brown-truenorthphp.md
+++ b/source/_others/2015-06-02-brown-truenorthphp.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - truenorthphp
-tags:
+colors:
     - brown
 name: Molly
 sponsor: Peter Meth / Softer Software

--- a/source/_others/2015-09-11-gray-hack.md
+++ b/source/_others/2015-09-11-gray-hack.md
@@ -1,7 +1,7 @@
 ---
 categories:
     - hack
-tags:
+colors:
     - gray
 sponsor: Facebook
 reverse: Hack logo

--- a/source/_sections/6-index.html
+++ b/source/_sections/6-index.html
@@ -2,13 +2,13 @@
 title: Index
 slug: index
 use:
-    - elephpants_tags
-    - others_tags
+    - elephpants_colors
+    - others_colors
 ---
 
 <p><strong>By Color and Year</strong></p>
 
-{% set animals = data.elephpants_tags|merge_recursive(data.others_tags) %}
+{% set animals = data.elephpants_colors|merge_recursive(data.others_colors) %}
 {% set colors = animals|keys|sort %}
 
 {% for color in colors %}


### PR DESCRIPTION
This PR converts the "tags" sculpin taxonomy for elephpants and others into a more-accurate "colors" taxonomy.