### PR TITLE
Remove right-to-left mark

### DIFF
--- a/source/_elephpants/2019-07-31-blue-linuxforphp.md
+++ b/source/_elephpants/2019-07-31-blue-linuxforphp.md
@@ -5,7 +5,7 @@ categories:
 tags:
     - blue
 sponsor: Linux for PHP
-‏reverse: Linux for PHP‏ logo
+reverse: Linux for PHP logo
 photos:
     -
         file: blue-blue-linuxforphp-0-400x300.jpg

--- a/source/_elephpants/2019-10-03-red-phpcon-poland.md
+++ b/source/_elephpants/2019-10-03-red-phpcon-poland.md
@@ -5,7 +5,7 @@ tags:
     - red
 name: Janusz
 sponsor: PHPCon Poland
-‏reverse: PHPCon Poland logo
+reverse: PHPCon Poland logo
 photos:
     -
         file: red-phpcon-poland-0-400x300.jpg


### PR DESCRIPTION
A right-to-left mark was added erroneously, causing the "Reverse" key to not be rendered