### PR TITLE
Convert all links to HTTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Contributions are welcome. All changes must be submitted via pull request.
   rendered in Latin. It is typically a direct or indirect translation of the common
   name or a creative related term.
   For translation guidance, see: https://en.wikipedia.org/wiki/Specific_name_(zoology) and
-  http://entnemdept.ufl.edu/frank/KISS/kiss24.htm
+  https://entnemdept.ufl.edu/frank/KISS/kiss24.htm
 * Some individuals are distinct enough from the elephpant that they should be categorized
   as a separate species. In this case the whole name is specified, e.g. <em>Elephpas mammuthus</em>.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elephant Field Guide
 
-Everything you need to know about [elephpants](http://php.net/elephpant.php)
+Everything you need to know about [elephpants](https://php.net/elephpant.php)
 in the wild. With acknowledgment to Roger Tory Peterson.
 
 ## Viewing Locally
@@ -30,5 +30,5 @@ feeds are licensed under the same terms as the website.
 ## License
 
 The content of A Field Guide to Elephpants is licensed under the [Creative
-Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/),
+Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/),
 and source code used to generate that content is licensed under the [MIT license](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "philipsharp/afieldguidetoelephpants",
     "description": "Everything you need to know about PHP's elephpant mascot in the wild.",
     "type": "project",
-    "homepage": "http://afieldguidetoelephpants.net",
+    "homepage": "https://afieldguidetoelephpants.net",
     "license": "MIT",
     "support": {
         "source": "https://github.com/philipsharp/afieldguidetoelephpants/"

--- a/source/_elephpants/2008-03-12-blue-oracle.md
+++ b/source/_elephpants/2008-03-12-blue-oracle.md
@@ -12,7 +12,7 @@ photos:
         credit: Anna Filina
     -
         file: blue-oracle-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/blue-oracle-1.jpg
+        link: https://web.archive.org/web/20211216005818if_/https://www.ojalehto.eu/elephpants/blue-oracle-1.jpg
         credit: Aki Ojalehto
 ---
 Given to attendees at the 2008 PHP Quebec Conference (now [ConFoo](https://confoo.ca/)),

--- a/source/_elephpants/2008-03-12-blue-oracle.md
+++ b/source/_elephpants/2008-03-12-blue-oracle.md
@@ -15,5 +15,5 @@ photos:
         link: https://www.ojalehto.eu/elephpants/blue-oracle-1.jpg
         credit: Aki Ojalehto
 ---
-Given to attendees at the 2008 PHP Quebec Conference (now [ConFoo](http://confoo.ca)), 
+Given to attendees at the 2008 PHP Quebec Conference (now [ConFoo](https://confoo.ca/)),
 and also to the attendees of the 2008 php|tek Conference (now [php[tek]](https://tek.phparch.com/)).

--- a/source/_elephpants/2010-11-01-blue-zend.md
+++ b/source/_elephpants/2010-11-01-blue-zend.md
@@ -8,11 +8,11 @@ reverse: Zend logo
 photos:
     -
         file: blue-zend-0-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/blue-zend-0.jpg
+        link: https://web.archive.org/web/20211216005756if_/https://www.ojalehto.eu/elephpants/blue-zend-0.jpg
         credit: Aki Ojalehto
     -
         file: blue-zend-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/blue-zend-1.jpg
+        link: https://web.archive.org/web/20211216005745if_/https://www.ojalehto.eu/elephpants/blue-zend-1.jpg
         credit: Aki Ojalehto
 ---
 First distributed to attendees at ZendCon 2010.

--- a/source/_elephpants/2011-10-00-pink-original.md
+++ b/source/_elephpants/2011-10-00-pink-original.md
@@ -11,7 +11,7 @@ photos:
         credit: Rob Allen
     -
         file: pink-original-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/pink-original-1.jpg
+        link: https://web.archive.org/web/20211216005829if_/https://www.ojalehto.eu/elephpants/pink-original-1.jpg
         credit: Aki Ojalehto
 ---
 This was the second color released. It was produced alongside the sixth generation of "original" blue elephpants.

--- a/source/_elephpants/2012-09-00-green-zf2.md
+++ b/source/_elephpants/2012-09-00-green-zf2.md
@@ -16,4 +16,4 @@ photos:
         credit: Ben Scholzen
 ---
 
-The green color matches the [Zend Framework](http://framework.zend.com/) logo.
+The green color matches the [Zend Framework](https://framework.zend.com/) logo.

--- a/source/_elephpants/2014-02-06-yellow-sunshinephp.md
+++ b/source/_elephpants/2014-02-06-yellow-sunshinephp.md
@@ -16,5 +16,5 @@ photos:
         link: https://www.flickr.com/photos/philipsharp/18289456670/
         credit: Philip Sharp
 ---
-The elephpant was originally designed for the [Sunshine PHP Conference](http://2015.sunshinephp.com/).
+The elephpant was originally designed for the [Sunshine PHP Conference](https://web.archive.org/web/20150206233417/https://2015.sunshinephp.com/).
 It was given out to attendees at the conference in 2014 and 2015.

--- a/source/_elephpants/2014-09-05-red-laravel.md
+++ b/source/_elephpants/2014-09-05-red-laravel.md
@@ -9,15 +9,15 @@ reverse: Laravel logo
 photos:
     -
         file: red-laravel-0-400x300.jpg
-        link: http://wilkins.fr/elephpants/IMG_4326.JPG
+        link: https://www.wilkins.fr/elephpants/IMG_4326.JPG
         credit: Thibault Taillandier
     -
         file: red-laravel-1-400x300.jpg
-        link: http://wilkins.fr/elephpants/IMG_4325.JPG
+        link: https://www.wilkins.fr/elephpants/IMG_4325.JPG
         credit: Thibault Taillandier
 ---
 
-This elephpant was produced via a [Kickstarter campaign](https://www.kickstarter.com/projects/1560940280/laravel-elephpant). The color matches the [Laravel](http://laravel.com/) logo.
+This elephpant was produced via a [Kickstarter campaign](https://www.kickstarter.com/projects/1560940280/laravel-elephpant). The color matches the [Laravel](https://laravel.com/) logo.
 
 In 2021 a new batch was made available [in the php[architect] store](https://www.phparch.com/swag/)
 

--- a/source/_elephpants/2014-11-27-black-amsterdamphp.md
+++ b/source/_elephpants/2014-11-27-black-amsterdamphp.md
@@ -16,7 +16,7 @@ photos:
         credit: Marco Rieger
 ---
 This elephpant was produced via a [Kickstarter campaign](https://www.kickstarter.com/projects/rdohms/the-amsterdamphp-elephpant).
-The colors match the [AmsterdamPHP](http://amsterdamphp.nl/) logo, which in turn
+The colors match the [AmsterdamPHP](https://php.amsterdam/) logo, which in turn
 match the flag and coat of arms of the City of Amsterdam.
 
 The name MurPHPy was kindly given by the organizers of AmsterdamPHP after facing a multitude of troubles during the packing and shipping stages of the campaign.

--- a/source/_elephpants/2014-11-27-black-amsterdamphp.md
+++ b/source/_elephpants/2014-11-27-black-amsterdamphp.md
@@ -20,5 +20,3 @@ The colors match the [AmsterdamPHP](https://php.amsterdam/) logo, which in turn
 match the flag and coat of arms of the City of Amsterdam.
 
 The name MurPHPy was kindly given by the organizers of AmsterdamPHP after facing a multitude of troubles during the packing and shipping stages of the campaign.
-
-Currently it's available for sale from the the [AmsterdamPHP Shop](http://amsterdamphp.webshopapp.com/).

--- a/source/_elephpants/2015-06-08-gold-opengoodies.md
+++ b/source/_elephpants/2015-06-08-gold-opengoodies.md
@@ -12,7 +12,7 @@ photos:
         credit: Adam Culp
         
 ---
-A true rarity, only one of these elephpants exists in the wild. It was designed by OpenGoodies to celebrate PHP's 20th anniversary on June 8, 2015. After developing the prototype the project was canceled because final production would not be ready in time. The single prototype was put up for auction on [Ebay](http://www.ebay.com/itm/2015-golden-elePHPant-PHP-039-s-20th-birthday-1995-to-2015-/321776947704) on the day of the anniversary. The auction was won by Zend Technologies co-founder Zeev Suraski. 
+A true rarity, only one of these elephpants exists in the wild. It was designed by OpenGoodies to celebrate PHP's 20th anniversary on June 8, 2015. After developing the prototype the project was canceled because final production would not be ready in time. The single prototype was put up for auction on [eBay](https://web.archive.org/web/20151102231504/https://www.ebay.com/itm/2015-golden-elePHPant-PHP-039-s-20th-birthday-1995-to-2015-/321776947704) on the day of the anniversary. The auction was won by Zend Technologies co-founder Zeev Suraski. 
 
 This is the first elephpant that does not have plush fur. It has a circular disc on the right-rear leg showing the "Official ElePHPant" logo.
 

--- a/source/_elephpants/2015-10-13-multicolored-haphpy.md
+++ b/source/_elephpants/2015-10-13-multicolored-haphpy.md
@@ -10,4 +10,4 @@ photos:
         caption: .
 ---
 
-This one-of-a-kind elephpant was handcrafted by V. Fanzutti. It has been offered to the Kenya PHP User Group for their contribution for the [20th HaPHPy Birthday](http://haphpy-birthday.net).
+This one-of-a-kind elephpant was handcrafted by V. Fanzutti. It has been offered to the Kenya PHP User Group for their contribution for the [20th HaPHPy Birthday](https://www.haphpy-birthday.net).

--- a/source/_elephpants/2015-10-19-teal-zend.md
+++ b/source/_elephpants/2015-10-19-teal-zend.md
@@ -8,7 +8,7 @@ reverse: Zend logo
 photos:
     -
         file: teal-zend-0-400x300.jpg
-        link: http://imgur.com/xJNpiQN
+        link: https://i.imgur.com/xJNpiQN.jpg
         credit: Mark Baker
     -
         file: teal-zend-1-400x300.jpg

--- a/source/_elephpants/2015-10-19-teal-zend.md
+++ b/source/_elephpants/2015-10-19-teal-zend.md
@@ -12,7 +12,7 @@ photos:
         credit: Mark Baker
     -
         file: teal-zend-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/teal-zend-1.jpg
+        link: https://web.archive.org/web/20211216005735if_/https://www.ojalehto.eu/elephpants/teal-zend-1.jpg
         credit: Aki Ojalehto
 ---
 Also described as turquoise. This elephpant was given away to attendees at ZendCon 2015.

--- a/source/_elephpants/2015-11-06-black-symfony-10-years.md
+++ b/source/_elephpants/2015-11-06-black-symfony-10-years.md
@@ -16,4 +16,4 @@ photos:
         credit: Aki Ojalehto
 ---
 
-This elephpant was designed to celebrate the 10th anniversary of the [Symfony Framework](https://symfony.com/). Only 300 were available and were sold exclusively at [SymfonyCon 2015](https://pariscon2015.symfony.com/) in Paris.
+This elephpant was designed to celebrate the 10th anniversary of the [Symfony Framework](https://symfony.com/). Only 300 were available and were sold exclusively at [SymfonyCon 2015](https://web.archive.org/web/20151208200303/https://pariscon2015.symfony.com/) in Paris.

--- a/source/_elephpants/2015-11-06-black-symfony-10-years.md
+++ b/source/_elephpants/2015-11-06-black-symfony-10-years.md
@@ -8,7 +8,7 @@ reverse: Symfony Framework 10 Years logo
 photos:
     -
         file: black-symfony-10-years-0-400x300.jpg
-        link: http://imgur.com/jnVQgQV
+        link: https://i.imgur.com/jnVQgQV.jpg
         credit: Mark Baker
     -
         file: black-symfony-10-years-1-400x300.jpg
@@ -16,4 +16,4 @@ photos:
         credit: Aki Ojalehto
 ---
 
-This elephpant was designed to celebrate the 10th anniversary of the [Symfony Framework](http://symfony.com/). Only 300 were available and were sold exclusively at [SymfonyCon 2015](http://pariscon2015.symfony.com/) in Paris.
+This elephpant was designed to celebrate the 10th anniversary of the [Symfony Framework](https://symfony.com/). Only 300 were available and were sold exclusively at [SymfonyCon 2015](https://pariscon2015.symfony.com/) in Paris.

--- a/source/_elephpants/2016-01-01-black-symfony.md
+++ b/source/_elephpants/2016-01-01-black-symfony.md
@@ -8,11 +8,11 @@ reverse: Symfony Framework logo
 photos:
     -
         file: black-symfony-0-400x300.jpg
-        link: http://imgur.com/hKdmTnK
+        link: https://imgur.com/hKdmTnK
         credit: Benjamin Jonard
     -
         file: black-symfony-1-400x300.jpg
-        link: http://imgur.com/YcdhzfU
+        link: https://imgur.com/YcdhzfU
         credit: Benjamin Jonard
 ---
 

--- a/source/_elephpants/2016-02-19-blue-shopware.md
+++ b/source/_elephpants/2016-02-19-blue-shopware.md
@@ -9,7 +9,7 @@ reverse: shopware Logo
 photos:
     -
         file: blue-shopware-0-400x300.jpg
-        link: http://imgur.com/eDISjV2
+        link: https://i.imgur.com/eDISjV2.jpg
         credit: Dennis Mader
     -
         file: blue-shopware-1-400x300.jpg

--- a/source/_elephpants/2016-02-19-blue-shopware.md
+++ b/source/_elephpants/2016-02-19-blue-shopware.md
@@ -13,7 +13,7 @@ photos:
         credit: Dennis Mader
     -
         file: blue-shopware-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/blue-shopware-0.jpg
+        link: https://web.archive.org/web/20211216005807if_/https://www.ojalehto.eu/elephpants/blue-shopware-0.jpg
         credit: Aki Ojalehto
 ---
 This elephant will be distributed primarily to [Shopware](https://github.com/shopware/shopware) contributors and community members.

--- a/source/_elephpants/2016-06-24-white-dpc.md
+++ b/source/_elephpants/2016-06-24-white-dpc.md
@@ -12,7 +12,7 @@ photos:
         credit: Mark Baker
     -
         file: white-dpc-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/white-dutch-php-conference-0.jpg
+        link: https://web.archive.org/web/20211216005756if_/https://www.ojalehto.eu/elephpants/white-dutch-php-conference-0.jpg
         credit: Aki Ojalehto
 ---
 This elephpant was given away to attendees at the 2016 Dutch PHP Conference.

--- a/source/_elephpants/2016-06-24-white-dpc.md
+++ b/source/_elephpants/2016-06-24-white-dpc.md
@@ -8,7 +8,7 @@ reverse: ibuildings Dutch PHP Conference, with the DPC logo
 photos:
     -
         file: white-dpc-0-400x300.jpg
-        link: http://i.imgur.com/DZvNywx.jpg
+        link: https://i.imgur.com/DZvNywx.jpg
         credit: Mark Baker
     -
         file: white-dpc-1-400x300.jpg

--- a/source/_elephpants/2016-10-18-white-zend.md
+++ b/source/_elephpants/2016-10-18-white-zend.md
@@ -9,11 +9,11 @@ reverse: Zend logo
 photos:
     -
         file: white-zend-0-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/white-zend-elvis-0.jpg
+        link: https://web.archive.org/web/20211216005756if_/https://www.ojalehto.eu/elephpants/white-zend-elvis-0.jpg
         credit: Aki Ojalehto
     -
         file: white-zend-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/white-zend-elvis-1.jpg
+        link: https://web.archive.org/web/20211216005735if_/https://www.ojalehto.eu/elephpants/white-zend-elvis-1.jpg
         credit: Aki Ojalehto
 ---
 This elephpant was given away to attendees at ZendCon 2016.

--- a/source/_elephpants/2016-10-27-multicolored-phpdiversity.md
+++ b/source/_elephpants/2016-10-27-multicolored-phpdiversity.md
@@ -8,11 +8,11 @@ sponsor: PHPDiversity
 photos:
     -
         file: multicolored-enfys-0-400x300.jpg
-        link: http://i.imgur.com/WESjIcA.jpg
+        link: https://i.imgur.com/WESjIcA.jpg
         credit: Mark Baker
     -
         file: multicolored-enfys-1-400x300.jpg
-        link: http://i.imgur.com/MBBKCPY.jpg
+        link: https://i.imgur.com/MBBKCPY.jpg
         credit: Mark Baker
 ---
 Inspired by a photoshopped image by a Slovenian PHP developer called Peter Kokot.

--- a/source/_elephpants/2017-05-19-blue-afup.md
+++ b/source/_elephpants/2017-05-19-blue-afup.md
@@ -8,11 +8,11 @@ reverse: AFUP logo
 photos:
     -
         file: blue-afup-0-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/blue-afup-0.jpg
+        link: https://web.archive.org/web/20211216005746if_/https://www.ojalehto.eu/elephpants/blue-afup-0.jpg
         credit: Aki Ojalehto
     -
         file: blue-afup-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/blue-afup-1.jpg
+        link: https://web.archive.org/web/20211216005735if_/https://www.ojalehto.eu/elephpants/blue-afup-1.jpg
         credit: Aki Ojalehto
 ---
 This elephpant was released in 2017 at AFUP's annual Forum PHP conference.

--- a/source/_elephpants/2017-10-12-gray-magento.md
+++ b/source/_elephpants/2017-10-12-gray-magento.md
@@ -8,10 +8,10 @@ reverse: Magento logo
 photos:
     -
         file: gray-magento-0-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/gray-magento-0.jpg
+        link: https://web.archive.org/web/20211216005734if_/https://www.ojalehto.eu/elephpants/gray-magento-0.jpg
         credit: Aki Ojalehto
     -
         file: gray-magento-1-400x300.jpg
-        link: https://www.ojalehto.eu/elephpants/gray-magento-1.jpg
+        link: https://web.archive.org/web/20211216005745if_/https://www.ojalehto.eu/elephpants/gray-magento-1.jpg
         credit: Aki Ojalehto
 ---

--- a/source/_elephpants/2020-11-28-php8-exakat.md
+++ b/source/_elephpants/2020-11-28-php8-exakat.md
@@ -17,4 +17,4 @@ photos:
 ---
 To celebrate the PHP8.0 release the original creators of the elePHPant, Damien
 Seguy and Vincent Pontier created inPHPinity, a Community Driven Elephpant.  It
-can be purchased [here](http://inphpinity.elephpant.com/)
+can be purchased [here](https://inphpinity.elephpant.com/)

--- a/source/_others/2015-06-02-brown-truenorthphp.md
+++ b/source/_others/2015-06-02-brown-truenorthphp.md
@@ -19,6 +19,6 @@ photos:
 This animal has smaller ears than an elephpant, and tusks. The body of the
 mammoth consists of both plush fur and longer hair.
 
-The woolly mammoth was produced as a giveaway for the 2015 [TrueNorth PHP Conference](http://truenorthphp.ca) in Toronto, Canada. A [Kickstarter campaign](https://www.kickstarter.com/projects/1035100786/truenorth-php-woolly-mammoth-plush-toy) was held to help fund the giveaways.
+The woolly mammoth was produced as a giveaway for the 2015 [TrueNorth PHP Conference](https://truenorthphp.ca) in Toronto, Canada. A [Kickstarter campaign](https://www.kickstarter.com/projects/1035100786/truenorth-php-woolly-mammoth-plush-toy) was held to help fund the giveaways.
 
 Due to a production delay, the mammoths were not available in time for the conference and were instead distributed to TrueNorth PHP attendees primarily through meetups in and around Toronto. The mammoths were released and started shipping to Kickstarter backers in January 2016.

--- a/source/_sections/7-colophon.md
+++ b/source/_sections/7-colophon.md
@@ -2,10 +2,10 @@
 title: Colophon
 slug: colophon
 ---
-This publication is typeset in [Old Standard TT](http://www.google.com/fonts/specimen/Old+Standard+TT),
-which is loaded from [Google Fonts](http://www.google.com/fonts).
+This publication is typeset in [Old Standard TT](https://www.google.com/fonts/specimen/Old+Standard+TT),
+which is loaded from [Google Fonts](https://www.google.com/fonts).
 
 The text of this publication is written in Markdown. The layout is written in HTML
-and and styled with CSS. The sources are stored in a [Git](http://git-scm.com/)
+and and styled with CSS. The sources are stored in a [Git](https://git-scm.com/)
 repository and hosted at [GitHub](https://github.com/). Final assembly is performed
 using [Sculpin](https://sculpin.io/). The publication is hosted on [GitHub Pages](https://pages.github.com/).

--- a/source/index.html
+++ b/source/index.html
@@ -22,15 +22,15 @@ use:
 
 <div class="copyright">
     <p>
-        <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">
+        <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
         <img alt="Creative Commons License" style="border-width:0"
         src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
     </p>
     <p>&copy; 2015-{{ "now"|date("y") }} Philip Sharp and contributors.</p>
-    <p>Elephpant logo by <a href="http://www.elroubio.net/">Vincent Pontier</a>.</p>
+    <p>Elephpant logo by <a href="https://www.elroubio.net/">Vincent Pontier</a>.</p>
     <p>
         The content of this website is licensed under the <a rel="license"
-        href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons
+        href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons
         Attribution-NonCommercial-ShareAlike 4.0 International License</a>.
     </p>
     <p>Last Updated: {{ "now"|date("Y-m-d H:i:s e") }}</p>


### PR DESCRIPTION
Thank you for contributing to A Field Guide to Elephpants. To speed up approval of your contribution, please review the following checklist:

* [x] I have read the [CONTRIBUTING](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/CONTRIBUTING.md) guide
* [x] All text and photographs included are licensed under [CC:BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/) or a compatible license.
* [x] (If Needed) New subspecies have been added to [sculpin_site.yml](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/app/config/sculpin_site.yml) following the naming convention.

----

This PR converts **all** `http://` links to `https://` except for:
* `source/index.html`: `http://www.elroubio.net/` (site has open port 443 but SSL handshake failed)
* `source/_elephpants/2015-10-13-multicolored-haphpy.md`: https://github.com/afup/haphpy-birthday is using GitHub Pages but is not configured to serve via the `haphpy-birthday.net` domain
* various links in composer.lock from 3rd party libraries