### PR TITLE
Add placeholder graphic for elePHPants that do not have photos

### DIFF
--- a/source/_partials/_animal.html
+++ b/source/_partials/_animal.html
@@ -1,6 +1,5 @@
     <div class="elephpant" id="e-{{ elephpant.categories|join('.') }}-{{ elephpant.tags|join('.') }}-{{ elephpant.date }}">
 
-        {% if elephpant.photos %}
         <div class="row">
             <div class="photos">
             {% for photo in elephpant.photos %}
@@ -19,11 +18,15 @@
                     <div class="caption">by {{ photo.credit }}</div>
                     {% endif %}
                 </div>
+            {% else %}
+                <div class="photo">
+                    <img src="images/elephpant-line-128.png" class="placeholder" alt="Placeholder graphic">
+					<div class="caption">&nbsp;</div>
+                </div>
             {% endfor %}
             </div>
         </div>
-        {% endif %}
-        
+
         {% if elephpant.commonname != "" %}
         <div class="row">
             <div class="box left"><div class="label">Common Name</div></div>

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -136,6 +136,10 @@ p { margin: 0 0 1em; }
     margin: auto;
 }
 
+.elephpant .photo .placeholder {
+    filter: grayscale(1) blur(5px) opacity(0.5);
+}
+
 .elephpant .photo .caption {
     font-size: .6em;
     text-align: right;


### PR DESCRIPTION
Originally proposed in https://github.com/philipsharp/afieldguidetoelephpants/pull/82

This works around the GPL issue by using the image already part of the project

----

Thank you for contributing to A Field Guide to Elephpants. To speed up approval of your contribution, please review the following checklist:

* [x] I have read the [CONTRIBUTING](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/CONTRIBUTING.md) guide
* [x] All text and photographs included are licensed under [CC:BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/) or a compatible license.
* [ ] (If Needed) New subspecies have been added to [sculpin_site.yml](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/app/config/sculpin_site.yml) following the naming convention.