### PR TITLE
Fix generation of JSON feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Generate site with Sculpin
+        run: vendor/bin/sculpin generate --env=prod
+
+      - name: Validate generated JSON
+        run: |
+          test -f output_prod/data/all.json || {
+            echo "output_prod/data/all.json was not generated"
+            exit 1
+          }
+          
+          jq empty output_prod/data/all.json
+          echo "JSON validation passed"
+
+      - name: Save generated site
+        uses: actions/upload-artifact@v7
+        with:
+          name: output_prod
+          path: output_prod

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,5 @@
-name: deploy
+name: Build and Deploy
+
 on:
   push:
     branches:
@@ -6,23 +7,21 @@ on:
 
 jobs:
   build:
+    uses: ./.github/workflows/build.yml
+
+  deploy:
+    needs: build
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-
-      - name: Install PHP dependencies
-        run: composer install
-
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-
-      - name: Generate site with Sculpin
-        run: vendor/bin/sculpin generate --env=prod
+      - name: Restore generated site
+        uses: actions/download-artifact@v7
+        with:
+          name: output_prod
+          path: output_prod
 
       - name: Push build to gh-pages branch
         uses: s0/git-publish-subdir-action@v2.6.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,9 @@
+name: PR Build
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml

--- a/src/JsonBundle/DependencyInjection/JsonCompilerPass.php
+++ b/src/JsonBundle/DependencyInjection/JsonCompilerPass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AFieldGuideToElephpants\JsonBundle\DependencyInjection;
+
+use AFieldGuideToElephpants\JsonBundle\JsonBuilder;
+use Sculpin\Core\Sculpin;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class JsonCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container
+            ->getDefinition('event_dispatcher')
+            ->addMethodCall('addListener', [
+                Sculpin::EVENT_AFTER_FORMAT,
+                [new Reference(JsonBuilder::BUNDLE_NAME), 'onSculpinCoreAfterFormat']
+            ]);
+    }
+}

--- a/src/JsonBundle/DependencyInjection/JsonExtension.php
+++ b/src/JsonBundle/DependencyInjection/JsonExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AFieldGuideToElephpants\JsonBundle\DependencyInjection;
+
+use AFieldGuideToElephpants\JsonBundle\JsonBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Reference;
+
+class JsonExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container
+            ->register(JsonBuilder::BUNDLE_NAME, JsonBuilder::class)
+            ->addArgument(new Reference('sculpin.site_configuration'))
+            ->addTag('kernel.event_listener', [
+                'event' => 'sculpin.core.after_format',
+                'method' => 'onSculpinCoreAfterFormat',
+            ]);
+    }
+}

--- a/src/JsonBundle/DynamicJsonSource.php
+++ b/src/JsonBundle/DynamicJsonSource.php
@@ -14,7 +14,7 @@ class DynamicJsonSource extends AbstractSource
     /**
      * @param string $filename Desired name of the file; used for the permalink
      */
-    public function __construct($filename)
+    public function __construct(string $filename)
     {
         $this->data = new Data();
         $this->isGenerated = true;
@@ -24,12 +24,12 @@ class DynamicJsonSource extends AbstractSource
     }
 
     /**
-     * @param array|mixed $content Content to render as JSON
+     * @param ?string $content Content to render as JSON
      */
     public function setContent(?string $content = null): void
     {
         parent::setContent($content);
-        $this->setFormattedContent(json_encode($content, JSON_PRETTY_PRINT));
+        $this->setFormattedContent($content);
 
         $this->hasChanged = true;
     }

--- a/src/JsonBundle/JsonBuilder.php
+++ b/src/JsonBundle/JsonBuilder.php
@@ -9,6 +9,8 @@ use Sculpin\Core\Source\SourceInterface;
 
 class JsonBuilder extends AbstractSource
 {
+    public const BUNDLE_NAME = 'json.builder';
+
     private $config;
 
     public function __construct(Configuration $config)
@@ -31,7 +33,7 @@ class JsonBuilder extends AbstractSource
 
         // Create new JSON file with the elephpant data
         $json = new DynamicJsonSource('data/all.json');
-        $json->setContent($elephpants);
+        $json->setContent(json_encode($elephpants, JSON_PRETTY_PRINT));
         $event->sourceSet()->mergeSource($json);
     }
 

--- a/src/JsonBundle/JsonBuilder.php
+++ b/src/JsonBundle/JsonBuilder.php
@@ -3,6 +3,7 @@
 namespace AFieldGuideToElephpants\JsonBundle;
 
 use Dflydev\DotAccessConfiguration\Configuration;
+use LogicException;
 use Sculpin\Core\Event\SourceSetEvent;
 use Sculpin\Core\Source\AbstractSource;
 use Sculpin\Core\Source\SourceInterface;
@@ -80,6 +81,8 @@ class JsonBuilder extends AbstractSource
         } elseif ($subspecies = $this->config->get('relatedspecies.'.$category)) {
             $species = $subspecies['latin'];
             $variation = $subspecies['common'];
+        } else {
+            throw new LogicException("Subspecies not found for $category.  It must be added to app/config/sculpin_site.yml");
         }
 
         return [$variation, $species];

--- a/src/JsonBundle/JsonBundle.php
+++ b/src/JsonBundle/JsonBundle.php
@@ -2,17 +2,14 @@
 
 namespace AFieldGuideToElephpants\JsonBundle;
 
+use AFieldGuideToElephpants\JsonBundle\DependencyInjection\JsonCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class JsonBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
-        $container
-            ->register('json.builder', 'AFieldGuideToElephpants\JsonBundle\JsonBuilder')
-            ->addArgument(new Reference('sculpin.site_configuration'))
-            ->addTag('kernel.event_listener', array('event' => 'sculpin.core.after_format'));
+        $container->addCompilerPass(new JsonCompilerPass());
     }
 }


### PR DESCRIPTION
Thank you for contributing to A Field Guide to Elephpants. To speed up approval of your contribution, please review the following checklist:

* [x] I have read the [CONTRIBUTING](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/CONTRIBUTING.md) guide
* [x] All text and photographs included are licensed under [CC:BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/) or a compatible license.
* [x] (If Needed) New subspecies have been added to [sculpin_site.yml](https://github.com/philipsharp/afieldguidetoelephpants/blob/master/app/config/sculpin_site.yml) following the naming convention.

----

This PR contains two commits:
* Fix generation of JSON feed
  Feed generation likely broke in a709efc04777ef0275401abd7bd91789119cc2f9
* Prevent building of site when species is missing in `sculpin_site.yml`
  Running `vendor/bin/sculpin generate` will now fail if a new category is added without its species being declared in `sculpin_site.yml`.  This check occurs when running locally and is also added to each PR as a smoke test.  Finally, we also validate that the JSON feed was generated, and that the JSON is valid.